### PR TITLE
fix: remove no-unused-variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,13 +217,6 @@ module.exports = {
      */
     'no-unused-expression': [true, 'allow-fast-null-checks'],
     /**
-     * Disallows unused imports, variables, functions and private
-     * class members. Similar to tsc’s –noUnusedParameters and
-     * –noUnusedLocals options, but does not interrupt code
-     * compilation.
-     */
-    'no-unused-variable': true,
-    /**
      * Disallows usage of variables before their declaration.
      */
     'no-use-before-declare': true,


### PR DESCRIPTION
> no-unused-variable is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.

This is unfortunate. You can test while there are lint errors, but you can't always test if there are compiler errors. In any case, it's in their changelog: https://github.com/palantir/tslint/blob/master/CHANGELOG.md#warning-deprecations