### PR TITLE
fix: remove typeof-compare

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,10 +270,6 @@ module.exports = {
      */
     'triple-equals': [true, 'allow-null-check'],
     /**
-     * Makes sure result of `typeof` is compared to correct string values
-     */
-    'typeof-compare': true,
-    /**
      * Enforces use of the isNaN() function to check for
      * NaN references instead of a comparison to the NaN
      * constant.


### PR DESCRIPTION
> typeof-compare is deprecated. Starting from TypeScript 2.2 the compiler includes this check which makes this rule redundant.