### PR TITLE
feat: remove match-default-export-name rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,12 +319,6 @@ module.exports = {
      */
     'jsdoc-format': true,
     /**
-     * Requires that a default import have the same name
-     * as the declaration it imports. Does nothing for
-     * anonymous default exports.
-     */
-    'match-default-export-name': true,
-    /**
      * Requires the use of `as Type` for type assertions instead of `<Type>`.
      */
     'no-angle-bracket-type-assertion': true,


### PR DESCRIPTION
I've found that default exports don't always have very sensible names, especially in third party packages. This is really the key advantage of a default export, is that you can call it whatever makes sense within the file your importing into.  Unless anyone finds it really useful, I'd like to disable this rule.