### PR TITLE
fix: swap switch-final-break

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,7 +358,7 @@ module.exports = {
      * Checks whether the final clause of a
      * `switch` statement ends in `break;`.
      */
-    'switch-final-break': true,
+    'switch-final-break': [true, 'always'],
     /**
      * Disallows variable names like `any`, `Number`, `string` etc.
      */


### PR DESCRIPTION
Before:

```typescript
switch (foo) {
  case 'a':
    console.log(a);
    break;
  case 'b':
    console.log(a);
}
```

After:

```typescript
switch (foo) {
  case 'a':
    console.log(a);
    break;
  case 'b':
    console.log(a);
    break;
}
```

To me, omitting the final break seems really odd, even though it is technically a no-op. I'd rather we enforce that there consistently is a final break included.