### PR TITLE
fix: make no-unbound-method rule false

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,10 +195,8 @@ module.exports = {
      * method call.
      *
      * Use arrow functions instead.
-     *
-     * Disabling due to many false positives in tests.
      */
-    'no-unbound-method': false,
+    'no-unbound-method': [true, "ignore-static"],
     /**
      * Disallows classes that are not strictly necessary.
      */

--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ module.exports = {
      * Warns when a method is used outside of a
      * method call.
      *
-     * Use arrow functions instead.
+     * Use arrow function properties instead.
      */
     'no-unbound-method': [true, "ignore-static"],
     /**

--- a/index.js
+++ b/index.js
@@ -194,9 +194,11 @@ module.exports = {
      * Warns when a method is used outside of a
      * method call.
      *
-     * Use arrow function properties instead.
+     * Use arrow functions instead.
+     *
+     * Disabling due to many false positives in tests.
      */
-    'no-unbound-method': true,
+    'no-unbound-method': false,
     /**
      * Disallows classes that are not strictly necessary.
      */


### PR DESCRIPTION
Triggers a lot in situations like this

`expect(Asset.fromImage).toHaveBeenCalledTimes(4);`

Or when mocking a function and replacing it later.