### PR TITLE
feat: 🎸 disabled no-inferred-empty-object-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,12 +142,6 @@ module.exports = {
      */
     'no-implicit-dependencies': [true, 'dev', 'optional'],
     /**
-     * Disallow type inference of `{}` (empty object type)
-     * at function and constructor call sites. It is better
-     * to use `unknown` if nothing is known about the result.
-     */
-    'no-inferred-empty-object-type': true,
-    /**
      * Warns on use of `${` in non-template strings.
      */
     'no-invalid-template-strings': true,


### PR DESCRIPTION
This PR remove a rule, this rule forced for example:

`const router = new Router();`
to be
`const router = new Router<any, {}>();`

`React.Component<P>`
to be
`React.Component<P, {}>`