### PR TITLE
fix: allow more recent versions of typescript/tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "typescript": "^2.9.2"
   },
   "peerDependencies": {
-    "tslint": "^5.10.0",
-    "typescript": "^2.9.2"
+    "tslint": "*",
+    "typescript": "*"
   },
   "dependencies": {
     "tslint-react": "^3.6.0"


### PR DESCRIPTION
We don't need to be so constrained with our peer dependencies. This works fine with the new release of typescript, and will probably work fine with the next one.