### PR TITLE
 feat: allow as const assertions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: node -v && npm -v && yarn -v
       - run:
           name: Install dependencies
-          command: yarn install
+          command: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - node_modules

--- a/index.js
+++ b/index.js
@@ -157,8 +157,10 @@ module.exports = {
     /**
      * Forbids an object literal to appear in a type assertion
      * expression. Casting to `any` is still allowed.
+     *
+     * Disabled because it prevents using the new `as const` syntax
      */
-    'no-object-literal-type-assertion': true,
+    'no-object-literal-type-assertion': false,
     /**
      * Disallows shadowing variable declarations.
      */
@@ -190,7 +192,7 @@ module.exports = {
      *
      * Use arrow function properties instead.
      */
-    'no-unbound-method': [true, "ignore-static"],
+    'no-unbound-method': [true, 'ignore-static'],
     /**
      * Disallows classes that are not strictly necessary.
      */

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prettier": "^1.14.0",
     "semantic-release": "^15.6.3",
     "tslint": "^5.10.0",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "^2.9.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,9 +2880,10 @@ tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-tslint-config-prettier@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.13.0.tgz#189e821931ad89e0364e4e292d5c44a14e90ecd6"
+tslint-config-prettier@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
+  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
 
 tslint-react@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
TypeScript has an awesome new feature called const assertions (https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#const-assertions) but our lint rules don't allow them to be used on object literals, which is a shame.